### PR TITLE
Fix typo in frame title from 'Sring' to 'String'

### DIFF
--- a/lectures/L05-slides.tex
+++ b/lectures/L05-slides.tex
@@ -74,7 +74,7 @@ MySQL has gotten better and made this a configurable parameter, but it's still s
 
 
 \begin{frame}
-\frametitle{Sring Operations}
+\frametitle{String Operations}
 
 Some functions familiar from C-like languages exist:\\
 \quad  \texttt{UPPER()}, \texttt{LOWER()}, \texttt{TRIM()}, et cetera. 


### PR DESCRIPTION
A simple typo fix